### PR TITLE
Execution Context Improvements, Logging Improvements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fixtury (0.1.0.rc1)
+    fixtury (0.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/fixtury/definition.rb
+++ b/lib/fixtury/definition.rb
@@ -55,12 +55,10 @@ module Fixtury
         args << store
       end
 
-      if args.length.positive?
-        execution_context_hooks(execution_context) do
+      execution_context_hooks(execution_context) do
+        if args.length.positive?
           execution_context.instance_exec(*args, &callable)
-        end
-      else
-        execution_context_hooks(execution_context) do
+        else
           execution_context.instance_eval(&callable)
         end
       end

--- a/lib/fixtury/definition.rb
+++ b/lib/fixtury/definition.rb
@@ -25,6 +25,8 @@ module Fixtury
     end
 
     def call(store: nil, execution_context: nil)
+      execution_context ||= ::Fixtury::ExecutionContext.new
+
       maybe_set_store_context(store: store) do
         value = run_callable(store: store, callable: callable, execution_context: execution_context, value: nil)
         enhancements.each do |e|
@@ -45,8 +47,6 @@ module Fixtury
     end
 
     def run_callable(store:, callable:, execution_context:, value:)
-      execution_context ||= self
-
       args = []
       args << value unless value.nil?
       if callable.arity > args.length
@@ -56,10 +56,25 @@ module Fixtury
       end
 
       if args.length.positive?
-        execution_context.instance_exec(*args, &callable)
+        execution_context_hooks(execution_context) do
+          execution_context.instance_exec(*args, &callable)
+        end
       else
-        execution_context.instance_eval(&callable)
+        execution_context_hooks(execution_context) do
+          execution_context.instance_eval(&callable)
+        end
       end
+    end
+
+    def execution_context_hooks(execution_context)
+      execution_context.before_fixture(self) if execution_context.respond_to?(:before_fixture)
+      value = if execution_context.respond_to?(:around_fixture)
+        execution_context.around_fixture(self) { yield }
+      else
+        yield
+      end
+      execution_context.after_fixture(self, value) if execution_context.respond_to?(:after_fixture)
+      value
     end
 
   end

--- a/lib/fixtury/execution_context.rb
+++ b/lib/fixtury/execution_context.rb
@@ -4,5 +4,13 @@
 module Fixtury
   class ExecutionContext
 
+    def before_fixture(_dfn); end
+
+    def around_fixture(_dfn)
+      yield
+    end
+
+    def after_fixture(_dfn, _value); end
+
   end
 end

--- a/lib/fixtury/store.rb
+++ b/lib/fixtury/store.rb
@@ -169,14 +169,14 @@ module Fixtury
       !locator.recognize?(ref.value)
     end
 
-    def log(level: LOG_LEVEL_DEBUG)
+    def log(level: LOG_LEVEL_DEBUG, name: "store")
       desired_level = LOG_LEVELS.fetch(log_level) { LOG_LEVEL_NONE }
       return if desired_level == LOG_LEVEL_NONE
 
       message_level = LOG_LEVELS.fetch(level) { LOG_LEVEL_DEBUG }
       return unless desired_level >= message_level
 
-      puts "[fixtury|store] #{yield}"
+      puts "[fixtury|#{name}] #{yield}"
     end
 
   end

--- a/lib/fixtury/version.rb
+++ b/lib/fixtury/version.rb
@@ -2,6 +2,6 @@
 
 module Fixtury
 
-  VERSION = "0.1.0.rc1"
+  VERSION = "0.1.0"
 
 end

--- a/test/fixtury/execution_context_test.rb
+++ b/test/fixtury/execution_context_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Fixtury
+  class ExecutionContextTest < Test
+
+    class ObserverExecutionContext < ::Fixtury::ExecutionContext
+
+      attr_reader :events
+
+      def initialize
+        @events = []
+      end
+
+      def before_fixture(*args)
+        @events << ["before", args]
+      end
+
+      def around_fixture(*args)
+        @events << ["around", args]
+        yield
+      end
+
+      def after_fixture(*args)
+        @events << ["after", args]
+      end
+
+    end
+
+    class NoInheritanceContext
+
+    end
+
+    class ModifyingExecutionContext < ::Fixtury::ExecutionContext
+
+      def around_fixture(_dfn)
+        value = yield
+        value * 2
+      end
+
+    end
+
+    def dfn
+      @dfn ||= ::Fixtury::Definition.new(name: "foo") { "foo" }
+    end
+
+    def test_execution_context_is_utilized_by_definitions
+      ctxt = ObserverExecutionContext.new
+      assert_equal [], ctxt.events
+
+      fixture = dfn.call(execution_context: ctxt)
+      expected = [
+        ["before", [dfn]],
+        ["around", [dfn]],
+        ["after", [dfn, fixture]],
+      ]
+      assert_equal(expected, ctxt.events)
+    end
+
+    def test_execution_contex_does_not_need_to_respond_to_hooks
+      ctxt = NoInheritanceContext.new
+      assert_equal "foo", dfn.call(execution_context: ctxt)
+    end
+
+    def test_execution_context_can_modify_the_fixture
+      ctxt = ModifyingExecutionContext.new
+      value = dfn.call(execution_context: ctxt)
+      assert_equal "foofoo", value
+    end
+
+  end
+end


### PR DESCRIPTION
Execution context can now provide before_fixture, around_fixture, and after_fixture hooks. around_fixture is given the opportunity to modify the result of the fixture as well. 

Logging is now a leveled setting { :debug, :info, :none }.