### PR TITLE
Consolidate `fixtury` usage in test hooks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fixtury (0.1.0)
+    fixtury (0.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/fixtury/store.rb
+++ b/lib/fixtury/store.rb
@@ -80,7 +80,7 @@ module Fixtury
     def clear_cache!(pattern: nil)
       pattern ||= "*"
       pattern = "/" + pattern unless pattern.start_with?("/")
-      glob = pattern.ends_with?("*")
+      glob = pattern.end_with?("*")
       pattern = pattern[0...-1] if glob
       references.delete_if do |key, _value|
         hit = glob ? key.start_with?(pattern) : key == pattern

--- a/lib/fixtury/version.rb
+++ b/lib/fixtury/version.rb
@@ -2,6 +2,6 @@
 
 module Fixtury
 
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 
 end

--- a/test/fixtury/integration_test.rb
+++ b/test/fixtury/integration_test.rb
@@ -82,10 +82,7 @@ module Fixtury
     end
 
     def test_relatives_can_access_parent_fixtures
-      $debug = true
       assert_equal "Town, Relative Earth", store["countries/towns/relative_town"]
-    ensure
-      $debug = false
     end
 
     def test_absolutes_can_be_used_from_nesting

--- a/test/fixtury/test_hooks_test.rb
+++ b/test/fixtury/test_hooks_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "fixtury/test_hooks"
+
+module Fixtury
+  class TestHooksTest < ::Test
+
+    class SomeTestClass
+
+      include ::Fixtury::TestHooks
+
+      # This is needed because we reset the global fixtures every time.
+      # Normally these calls would occur directly on the class
+      def self.bootstrap
+        fixtury "global/foo"
+        fixtury "global/bar", accessor: "barrr"
+        fixtury "global/baz", accessor: true
+
+        fixtury "qux" do |_store|
+          "qux"
+        end
+
+        fixtury "bux", accessor: true do
+          "bux"
+        end
+      end
+
+      def fixtury_store
+        @fixtury_store ||= ::Fixtury::Store.new(schema: ::Fixtury.schema)
+      end
+
+    end
+
+    let(:schema) do
+      ::Fixtury.define do
+        namespace "global" do
+          fixture "foo" do
+            "foo"
+          end
+
+          fixture "reverse_foo" do |store|
+            store["foo"].reverse
+          end
+
+          fixture "bar" do
+            "bar"
+          end
+        end
+      end
+    end
+
+    def setup
+      super
+      schema
+      SomeTestClass.bootstrap
+    end
+
+    def test_dependencies_are_recorded
+      assert_equal(
+        %w[global/foo global/bar global/baz fixtury/test_hooks_test/some_test_class/qux fixtury/test_hooks_test/some_test_class/bux],
+        SomeTestClass.fixtury_dependencies.to_a
+      )
+    end
+
+    def test_accessors_are_created
+      instance = SomeTestClass.new
+
+      assert_equal false, instance.respond_to?(:foo)
+      assert_equal false, instance.respond_to?(:qux)
+      assert_equal false, instance.respond_to?(:bar)
+      assert_equal true, instance.respond_to?(:barrr)
+      assert_equal true, instance.respond_to?(:baz)
+      assert_equal true, instance.respond_to?(:bux)
+    end
+
+    def test_fixtures_are_accessible
+      instance = SomeTestClass.new
+
+      assert_equal "foo", instance.fixtury("global/foo")
+      assert_equal "bar", instance.barrr
+
+      assert_raises Fixtury::Errors::FixtureNotDefinedError do
+        instance.baz
+      end
+
+      assert_equal "qux", instance.fixtury("qux")
+      assert_equal "bux", instance.fixtury("bux")
+      assert_equal "bux", instance.bux
+    end
+
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require "fixtury"
 require "byebug"
 require "minitest/autorun"
 require "minitest/reporters"
+
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
 class Test < Minitest::Test
@@ -21,4 +22,4 @@ end
 
 ::MiniTest::Runnable.runnables.delete Test
 
-require "mocha/mini_test"
+require "mocha/minitest"


### PR DESCRIPTION
Allows for fixture definitions to be defined via the `fixtury` method. It also allows accessors to be defined via the `fixtury` method.