### PR TITLE
Improving error message from dump_ref in Store

### DIFF
--- a/lib/fixtury/store.rb
+++ b/lib/fixtury/store.rb
@@ -141,8 +141,12 @@ module Fixtury
       locator.load(ref)
     end
 
-    def dump_ref(_name, value)
-      locator.dump(value)
+    def dump_ref(name, value)
+      begin
+        locator.dump(value)
+      rescue ArgumentError => err
+        raise ArgumentError, "#{err.to_s} for #{name}"
+      end
     end
 
     def clear_ref(name)


### PR DESCRIPTION
handling the ArgumentError from locator.dump in dump_ref so we can append the name to the error for debugging