### PR TITLE
Drop Ruby 3.2 from CI test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [3.2, 3.3, 3.4]
+        ruby-version: [3.3, 3.4]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fixtury (2.2.0)
+    fixtury (2.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -108,7 +108,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  fixtury (2.2.0)
+  fixtury (2.3.0)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/fixtury.gemspec
+++ b/fixtury.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "sqlite3"
 
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3.0"
 end

--- a/gemfiles/rails_7.2.gemfile.lock
+++ b/gemfiles/rails_7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fixtury (2.2.0)
+    fixtury (2.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -107,7 +107,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  fixtury (2.2.0)
+  fixtury (2.3.0)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/gemfiles/rails_8.0.gemfile.lock
+++ b/gemfiles/rails_8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fixtury (2.2.0)
+    fixtury (2.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -109,7 +109,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  fixtury (2.2.0)
+  fixtury (2.3.0)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/gemfiles/rails_8.1.gemfile.lock
+++ b/gemfiles/rails_8.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fixtury (2.2.0)
+    fixtury (2.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -108,7 +108,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  fixtury (2.2.0)
+  fixtury (2.3.0)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/gemfiles/rails_8.1_minitest_5.gemfile.lock
+++ b/gemfiles/rails_8.1_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fixtury (2.2.0)
+    fixtury (2.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -105,7 +105,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  fixtury (2.2.0)
+  fixtury (2.3.0)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/lib/fixtury/version.rb
+++ b/lib/fixtury/version.rb
@@ -3,7 +3,7 @@
 module Fixtury
 
   MAJOR       = 2
-  MINOR       = 2
+  MINOR       = 3
   PATCH       = 0
   PRERELEASE  = nil
 


### PR DESCRIPTION
Remove Ruby 3.2 from CI test matrix, bump minor version.

Ruby 3.2 EOL prep — aligning CI matrix with supported versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it is a compatibility-breaking support change: users on Ruby 3.2 (and CI coverage for it) are removed, which may affect downstream consumers relying on 3.2.
> 
> **Overview**
> **Removes Ruby 3.2 from support/verification.** The GitHub Actions build matrix now tests only Ruby `3.3` and `3.4`, and the gemspec raises `required_ruby_version` to `>= 3.3.0`.
> 
> Bumps the gem minor version from `2.2.0` to `2.3.0` (including updating all relevant lockfiles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 059c8d7cb033646c45013ed98cc77e370dab5d26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->