### PR TITLE
Add :load hook fired on cached fixture access

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fixtury (2.3.0)
+    fixtury (2.4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -108,7 +108,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  fixtury (2.3.0)
+  fixtury (2.4.0)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/lib/fixtury/store.rb
+++ b/lib/fixtury/store.rb
@@ -121,6 +121,11 @@ module Fixtury
       pathname = dfn.pathname
       isokey = dfn.isolation_key
 
+      # Capture whether a real reference existed before isolation-dependency loading,
+      # so we can distinguish a true cache hit from a reference materialized by the
+      # recursive isolation build path.
+      pre_existing_real_ref = !!references[pathname]&.real?
+
       # Ensure that if we're part of an isolation group, we load all the fixtures in that group.
       maybe_load_isolation_dependencies(isokey)
 
@@ -138,6 +143,7 @@ module Fixtury
         log("refreshing #{pathname}", level: LOG_LEVEL_DEBUG)
         clear_reference(pathname)
         ref = nil
+        pre_existing_real_ref = false
       end
 
       value = nil
@@ -149,6 +155,8 @@ module Fixtury
           clear_reference(pathname)
           ref = nil
           log("missing #{pathname}", level: LOG_LEVEL_ALL)
+        elsif pre_existing_real_ref
+          ::Fixtury.hooks.call(:load, dfn, value) { value }
         end
       end
 

--- a/lib/fixtury/version.rb
+++ b/lib/fixtury/version.rb
@@ -3,7 +3,7 @@
 module Fixtury
 
   MAJOR       = 2
-  MINOR       = 3
+  MINOR       = 4
   PATCH       = 0
   PRERELEASE  = nil
 

--- a/test/fixtury/store_test.rb
+++ b/test/fixtury/store_test.rb
@@ -113,5 +113,65 @@ module Fixtury
       assert_equal "baz", store["foo"]
     end
 
+    def test_load_hook_fires_on_cache_hit
+      fresh_hooks = ::Fixtury::Hooks.new
+      ::Fixtury.stubs(:hooks).returns(fresh_hooks)
+
+      calls = []
+      fresh_hooks.on(:load) { |dfn, value| calls << [dfn.pathname, value] }
+
+      store = ::Fixtury::Store.new(schema: schema)
+      store["foo"]
+      assert_equal [], calls, ":load should not fire on initial cache-miss build"
+
+      store["foo"]
+      assert_equal [["/test/foo", "foo"]], calls
+    end
+
+    def test_load_hook_does_not_fire_on_initial_build
+      fresh_hooks = ::Fixtury::Hooks.new
+      ::Fixtury.stubs(:hooks).returns(fresh_hooks)
+
+      calls = []
+      fresh_hooks.on(:load) { |_dfn, _value| calls << :load }
+
+      store = ::Fixtury::Store.new(schema: schema)
+      store["foo"]
+
+      assert_equal [], calls
+    end
+
+    def test_load_hook_does_not_fire_when_locator_returns_nil
+      fresh_hooks = ::Fixtury::Hooks.new
+      ::Fixtury.stubs(:hooks).returns(fresh_hooks)
+
+      store = ::Fixtury::Store.new(schema: schema)
+      store["foo"]
+
+      calls = []
+      fresh_hooks.on(:load) { |_dfn, _value| calls << :load }
+      store.locator.stubs(:load).returns(nil)
+
+      store["foo"]
+
+      assert_equal [], calls
+    end
+
+    def test_multiple_load_hooks_fire_in_registration_order
+      fresh_hooks = ::Fixtury::Hooks.new
+      ::Fixtury.stubs(:hooks).returns(fresh_hooks)
+
+      calls = []
+      fresh_hooks.on(:load) { |_dfn, _value| calls << :first }
+      fresh_hooks.on(:load) { |_dfn, _value| calls << :second }
+      fresh_hooks.on(:load) { |_dfn, _value| calls << :third }
+
+      store = ::Fixtury::Store.new(schema: schema)
+      store["foo"]
+      store["foo"]
+
+      assert_equal [:first, :second, :third], calls
+    end
+
   end
 end


### PR DESCRIPTION
## Motivation

Cached fixtures can hold values whose validity depends on real-world time (e.g., a `start_date` aligned to a calendar payroll boundary). Today fixtury exposes `:execution` and `:time_access` triggers, which only fire on cache miss / time access — there is no callback when a cached fixture is restored via the locator on each test run, so downstream consumers have no clean place to refresh stale per-test state.

This adds a `:load` trigger that fires inside `Fixtury::Store#get` when a cached reference is successfully resolved by the locator, passing `(definition, value)` to hook callbacks. It deliberately does **not** fire on the cache-miss build path (`:execution` already covers that) or on the recovery rebuild path when the locator returns `nil`.

## Intended consumer usage

```ruby
::Fixtury.hooks.on(:load) do |dfn, value|
  ProspectStartDateBuffer.apply!(value) if value.is_a?(::Prospect)
end
```

## Implementation notes

`Store#get` calls `maybe_load_isolation_dependencies` before the cache-hit check, and that path can recursively call `get` for the same fixture (when the fixture's `isolation_key` defaults to its own pathname). That recursive call builds and stores the reference, so the outer call would otherwise observe a synthetic cache hit on the very first `get`. To distinguish a true cache hit from this build-via-isolation-recursion case, we capture the reference state before isolation-dependency loading and only fire `:load` when a real reference existed beforehand.

Bumps version to 2.4.0 (additive, no breaking changes).

## Test plan

- [x] `bundle exec rake test` — 74 runs, 171 assertions, 0 failures
- [x] `:load` fires on cache hit
- [x] `:load` does not fire on initial cache-miss build
- [x] `:load` does not fire when locator returns nil (recovery rebuild)
- [x] Multiple `:load` hooks fire in registration order

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core fixture retrieval path (`Store#get`) and introduces a new callback that can run user code on cache hits, which could affect test behavior/performance if misused.
> 
> **Overview**
> Adds a new `:load` hook that fires when `Fixtury::Store#get` successfully resolves a *cached* fixture via the locator, passing `(definition, value)` for consumers to refresh per-test state.
> 
> Updates `Store#get` to avoid false positives caused by isolation-group dependency loading (only firing when a real reference existed before dependency loading) and to skip the hook when the locator returns `nil` and a rebuild occurs; adds tests covering these cases and bumps the gem version to `2.4.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c9168f85afbd12f1dca1e070fe9baff1c6a957e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->