### PR TITLE
Add factory mode for building fixtures without caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ end
 
 As you can see fixtures are named in a nested structure and can refer to each other via dependencies. See Fixtury::Dependency for more specifics.
 
+## Factory Mode
+
+Fixture definitions can also be used as factories. `Fixtury.factory` invokes the definition every time it's called and never stores the result, making it useful for generating new records on demand without mutating the global cache.
+
+```ruby
+user_a = Fixtury.factory("users/fresh")
+user_b = Fixtury.factory("users/fresh")
+user_a == user_b # => false, each call builds a new record
+```
+
+By default, dependencies of the definition are resolved through an ephemeral store: they are built fresh for the invocation and discarded afterwards. Within a single invocation a shared dependency is only built once.
+
+If the dependency tree is expensive to build, a dedicated store can be used instead:
+
+```ruby
+Fixtury.factory("users/fresh", store: :my_cache)
+```
+
+Dependencies will be resolved through (and cached in) a dedicated store named `:my_cache`, shared across factory invocations using the same store name. The named store is bootstrapped from its own file, derived from the configured filepath — e.g. `tmp/fixtury.yml` produces `tmp/fixtury.my_cache.yml` — and is persisted alongside the default store when `Fixtury.configuration.dump_file` is called. In all cases the target definition itself is always invoked and its result is never stored.
+
 ## Isolation Levels
 
 Isolation keys enable groups of fixtures to use and modify the same resources. When one fixture from an isolation level is built, all fixtures in that isolation level are built. This allows multiple fixtures to potentially mutate a resource while keeping the definition consistent.

--- a/lib/fixtury.rb
+++ b/lib/fixtury.rb
@@ -111,7 +111,12 @@ module Fixtury
     raise ArgumentError, "#{search.inspect} must refer to a definition" unless dfn.acts_like?(:fixtury_definition)
 
     factory_store = store ? self.store(store) : ::Fixtury::Store.new(name: nil)
-    ::Fixtury::DefinitionExecutor.new(store: factory_store, definition: dfn).call.value
+
+    # Hold the target's reference while executing so recursive loading behaviors,
+    # such as isolation group preloading, do not build and cache the target themselves.
+    factory_store.holding(dfn.pathname) do
+      ::Fixtury::DefinitionExecutor.new(store: factory_store, definition: dfn).call.value
+    end
   end
 
   # Load all known fixture files configured in Configuration. Reset the store references if

--- a/lib/fixtury.rb
+++ b/lib/fixtury.rb
@@ -74,8 +74,44 @@ module Fixtury
   end
 
   # Default store for fixtures. This is a shared store that can be used across the application.
-  def self.store
-    @store ||= ::Fixtury::Store.new
+  # A name can be provided to access a dedicated store instead. Named stores behave just like
+  # the default store but are bootstrapped from (and dumped to) their own file. e.g. a name of
+  # :my_cache would utilize a fixtury.my_cache.yml file alongside the default fixtury.yml.
+  #
+  # @param name [Symbol, String] The name of the store to access.
+  # @return [Fixtury::Store] The store associated with the given name.
+  def self.store(name = :default)
+    name = name.to_sym
+    stores[name] ||= ::Fixtury::Store.new(name: name)
+  end
+
+  # All shared stores that have been instantiated, keyed by name.
+  #
+  # @return [Hash<Symbol, Fixtury::Store>]
+  def self.stores
+    @stores ||= {}
+  end
+
+  # Invoke a definition without caching the result. The definition is executed every time,
+  # making this useful for generating new records on demand without mutating the global cache.
+  #
+  # By default the definition's dependencies are resolved through an ephemeral store, meaning
+  # they are built fresh and discarded afterwards. If a store name is provided, dependencies
+  # are resolved through (and cached in) the named store instead, which is bootstrapped from
+  # its own file. e.g. factory("some/definition", store: :my_cache) would resolve dependencies
+  # via a store backed by fixtury.my_cache.yml. In both cases the definition itself is always
+  # invoked and its result is never stored.
+  #
+  # @param search [String] The name of the definition to invoke.
+  # @param store [Symbol, String, nil] The name of a dedicated store to resolve dependencies through.
+  # @return [Object] The newly built value.
+  # @raise [ArgumentError] if the search does not refer to a definition.
+  def self.factory(search, store: nil)
+    dfn = schema.get!(search)
+    raise ArgumentError, "#{search.inspect} must refer to a definition" unless dfn.acts_like?(:fixtury_definition)
+
+    factory_store = store ? self.store(store) : ::Fixtury::Store.new(name: nil)
+    ::Fixtury::DefinitionExecutor.new(store: factory_store, definition: dfn).call.value
   end
 
   # Load all known fixture files configured in Configuration. Reset the store references if
@@ -104,10 +140,10 @@ module Fixtury
     store.load_all
   end
 
-  # Remove all references from the active store and reset the dependency file.
+  # Remove all references from the active stores and reset the dependency files.
   def self.reset
     configuration.reset
-    store.reset
+    stores.each_value(&:reset)
   end
 
   # Perform a reset if any of the tracked files have changed.

--- a/lib/fixtury/configuration.rb
+++ b/lib/fixtury/configuration.rb
@@ -32,10 +32,11 @@ module Fixtury
       @locator_backend = backend.to_sym
     end
 
-    # Delete the storage file(s) if they exist. This includes the files backing
-    # any named stores. e.g. tmp/fixtury.yml and tmp/fixtury.*.yml
+    # Delete the storage file(s) if they exist. Named store files are discovered by
+    # globbing the filesystem (e.g. tmp/fixtury.yml and tmp/fixtury.*.yml) so files
+    # from stores not instantiated in this process are removed as well.
     def reset
-      store_filepaths.each { |path| File.delete(path) if File.file?(path) }
+      persisted_filepaths.each { |path| File.delete(path) if File.file?(path) }
     end
 
     # The file backing the references of the given store. The default store
@@ -140,7 +141,9 @@ module Fixtury
       YAML.unsafe_load_file(path)
     end
 
-    def store_filepaths
+    # All storage files currently on disk: the configured filepath plus any
+    # named store files matching its naming pattern.
+    def persisted_filepaths
       return [] unless filepath
 
       ext = File.extname(filepath)

--- a/lib/fixtury/configuration.rb
+++ b/lib/fixtury/configuration.rb
@@ -32,9 +32,25 @@ module Fixtury
       @locator_backend = backend.to_sym
     end
 
-    # Delete the storage file if it exists.
+    # Delete the storage file(s) if they exist. This includes the files backing
+    # any named stores. e.g. tmp/fixtury.yml and tmp/fixtury.*.yml
     def reset
-      File.delete(filepath) if filepath && File.file?(filepath)
+      store_filepaths.each { |path| File.delete(path) if File.file?(path) }
+    end
+
+    # The file backing the references of the given store. The default store
+    # uses the configured filepath directly while named stores embed their name
+    # in the filename. e.g. tmp/fixtury.yml => tmp/fixtury.my_cache.yml
+    #
+    # @param name [Symbol, String] The name of the store.
+    # @return [String, nil] The filepath for the given store, nil if no filepath is configured.
+    def store_filepath(name = :default)
+      name = (name || :default).to_sym
+      return filepath if name == :default
+      return nil unless filepath
+
+      ext = File.extname(filepath)
+      File.join(File.dirname(filepath), "#{File.basename(filepath, ext)}.#{name}#{ext}")
     end
 
     # Add a file or glob pattern to the list of fixture files.
@@ -53,22 +69,31 @@ module Fixtury
     end
     alias add_dependency_paths add_dependency_path
 
-    # The references stored in the dependency file. When stores are initialized
-    # these will be used to bootstrap the references.
+    # The references stored in the file backing the given store. When stores are
+    # initialized these will be used to bootstrap the references.
     #
-    # @return [Hash] The references stored in the dependency file.
-    def stored_references
-      return {} if stored_data.nil?
+    # @param name [Symbol, String] The name of the store.
+    # @return [Hash] The references stored in the store's file.
+    def stored_references(name = :default)
+      data = stored_data(store_filepath(name))
+      return {} if data.nil?
 
-      stored_data[:references] || {}
+      data[:references] || {}
     end
 
-    # Dump the current state of the dependency manager to the storage file.
+    # Dump the current state of the dependency manager to the storage files.
+    # Each instantiated store is dumped to the file associated with its name.
     def dump_file
       return unless filepath
 
-      FileUtils.mkdir_p(File.dirname(filepath))
-      File.binwrite(filepath, file_data.to_yaml)
+      ::Fixtury.store # ensure the default store is present
+      ::Fixtury.stores.each_value do |store|
+        path = store_filepath(store.name)
+        next unless path
+
+        FileUtils.mkdir_p(File.dirname(path))
+        File.binwrite(path, file_data(store.references).to_yaml)
+      end
     end
 
     def changes
@@ -96,7 +121,7 @@ module Fixtury
 
     private
 
-    def file_data
+    def file_data(references)
       checksums = {}
       calculate_checksums do |filepath, checksum|
         checksums[filepath] = checksum
@@ -104,15 +129,23 @@ module Fixtury
 
       {
         dependencies: checksums,
-        references: ::Fixtury.store.references,
+        references: references,
       }
     end
 
-    def stored_data
-      return nil unless filepath
-      return nil unless File.file?(filepath)
+    def stored_data(path = filepath)
+      return nil unless path
+      return nil unless File.file?(path)
 
-      YAML.unsafe_load_file(filepath)
+      YAML.unsafe_load_file(path)
+    end
+
+    def store_filepaths
+      return [] unless filepath
+
+      ext = File.extname(filepath)
+      glob = File.join(File.dirname(filepath), "#{File.basename(filepath, ext)}.*#{ext}")
+      [filepath, *Dir[glob]]
     end
 
     def calculate_checksums(&block)

--- a/lib/fixtury/store.rb
+++ b/lib/fixtury/store.rb
@@ -98,6 +98,26 @@ module Fixtury
       @schema = prior
     end
 
+    # Temporarily place a holder reference at the given pathname while the block executes.
+    # This prevents the store from building and caching the fixture (e.g. via isolation
+    # group loading) while still allowing other fixtures to be resolved. Any pre-existing
+    # reference is restored when the block completes.
+    #
+    # @param pathname [String] The pathname to hold.
+    # @yield [void] The block to execute while the reference is held.
+    # @return [Object] The result of the block.
+    def holding(pathname)
+      prior = references[pathname]
+      references[pathname] = ::Fixtury::Reference.holder(pathname)
+      yield
+    ensure
+      if prior
+        references[pathname] = prior
+      else
+        references.delete(pathname)
+      end
+    end
+
     # Is a fixture for the given search already loaded?
     #
     # @param search [String] The name of the fixture to search for.

--- a/lib/fixtury/store.rb
+++ b/lib/fixtury/store.rb
@@ -11,12 +11,19 @@ module Fixtury
   class Store
 
     attr_reader :locator
+    attr_reader :name
     attr_reader :schema
 
-    def initialize(schema: nil)
+    # @param schema [Fixtury::Schema] The schema to use, defaults to the global schema.
+    # @param name [Symbol, String, nil] The name of this store. The name determines
+    #   which file the references are bootstrapped from (see
+    #   Fixtury::Configuration#store_filepath). A nil name produces an ephemeral store
+    #   that starts empty and is never persisted.
+    def initialize(schema: nil, name: :default)
+      @name = name&.to_sym
       @schema = schema || ::Fixtury.schema
       @locator = ::Fixtury::Locator.from(::Fixtury.configuration.locator_backend)
-      self.references = ::Fixtury.configuration.stored_references
+      self.references = @name ? ::Fixtury.configuration.stored_references(@name) : {}
     end
 
     def references
@@ -45,6 +52,7 @@ module Fixtury
     # @return [String]
     def inspect
       parts = []
+      parts << "name: #{name.inspect}" if name
       parts << "schema: #{schema.inspect}"
       parts << "locator: #{locator.inspect}"
       parts << "ttl: #{ttl.inspect}" if ttl

--- a/test/fixtury/factory_test.rb
+++ b/test/fixtury/factory_test.rb
@@ -97,6 +97,43 @@ module Fixtury
       assert_equal %w[/dependency], ::Fixtury.store(:my_cache).references.keys
     end
 
+    def test_factory_target_is_not_built_or_cached_by_isolation_loading
+      built = []
+      ::Fixtury.define do
+        namespace "group", isolate: true do
+          fixture("sibling") do
+            built << :sibling
+            "sibling"
+          end
+          fixture("record", deps: "sibling") do |deps|
+            value = "record built with #{deps.sibling}"
+            built << :record
+            value
+          end
+        end
+      end
+
+      value = ::Fixtury.factory("group/record", store: :my_cache)
+
+      assert_equal "record built with sibling", value
+      assert_equal [:sibling, :record], built
+      assert_equal %w[/group/sibling], ::Fixtury.store(:my_cache).references.keys
+    end
+
+    def test_factory_preserves_an_existing_reference_for_the_target
+      ::Fixtury.define do
+        fixture("record") { "record" }
+      end
+
+      named_store = ::Fixtury.store(:my_cache)
+      named_store.get("record")
+      ref = named_store.references["/record"]
+
+      ::Fixtury.factory("record", store: :my_cache)
+
+      assert_equal ref, named_store.references["/record"]
+    end
+
     def test_factory_requires_a_definition
       ::Fixtury.define do
         namespace "things" do

--- a/test/fixtury/factory_test.rb
+++ b/test/fixtury/factory_test.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+module Fixtury
+  class FactoryTest < ::Test
+
+    def before_setup
+      super
+      ::Fixtury.stores.clear
+    end
+
+    def teardown
+      ::Fixtury.configuration.filepath = nil
+      ::Fixtury.stores.clear
+      super
+    end
+
+    def test_factory_invokes_the_definition_every_time
+      built = []
+      ::Fixtury.define do
+        fixture("record") do
+          built << :record
+          "record-#{built.length}"
+        end
+      end
+
+      assert_equal "record-1", ::Fixtury.factory("record")
+      assert_equal "record-2", ::Fixtury.factory("record")
+      assert_equal 2, built.length
+    end
+
+    def test_factory_does_not_mutate_the_global_store
+      ::Fixtury.define do
+        fixture("dependency") { "dep" }
+        fixture("record", deps: "dependency") { |deps| "record built with #{deps.dependency}" }
+      end
+
+      ::Fixtury.factory("record")
+
+      assert_equal true, ::Fixtury.store.references.empty?
+    end
+
+    def test_factory_builds_dependencies_fresh_by_default
+      built = []
+      ::Fixtury.define do
+        fixture("dependency") do
+          built << :dependency
+          "dep"
+        end
+        fixture("record", deps: "dependency") { |deps| deps.dependency }
+      end
+
+      ::Fixtury.factory("record")
+      ::Fixtury.factory("record")
+
+      assert_equal 2, built.length
+    end
+
+    def test_factory_builds_shared_dependencies_once_per_invocation
+      built = []
+      ::Fixtury.define do
+        fixture("dependency") do
+          built << :dependency
+          "dep"
+        end
+        fixture("a", deps: "dependency") { |deps| deps.dependency }
+        fixture("record", deps: %w[a dependency]) { |deps| "#{deps.a} #{deps.dependency}" }
+      end
+
+      ::Fixtury.factory("record")
+
+      assert_equal 1, built.length
+    end
+
+    def test_factory_with_a_dedicated_store_reuses_dependencies_across_invocations
+      built = []
+      ::Fixtury.define do
+        fixture("dependency") do
+          built << :dependency
+          "dep"
+        end
+        fixture("record", deps: "dependency") do |deps|
+          value = deps.dependency
+          built << :record
+          value
+        end
+      end
+
+      ::Fixtury.factory("record", store: :my_cache)
+      ::Fixtury.factory("record", store: :my_cache)
+
+      # The dependency is cached in the dedicated store while the target is built every time.
+      assert_equal [:dependency, :record, :record], built
+      assert_equal true, ::Fixtury.store.references.empty?
+      assert_equal %w[/dependency], ::Fixtury.store(:my_cache).references.keys
+    end
+
+    def test_factory_requires_a_definition
+      ::Fixtury.define do
+        namespace "things" do
+          fixture("record") { "record" }
+        end
+      end
+
+      assert_raises ArgumentError do
+        ::Fixtury.factory("things")
+      end
+    end
+
+    def test_named_stores_bootstrap_from_their_own_file
+      Dir.mktmpdir do |dir|
+        ::Fixtury.configuration.filepath = File.join(dir, "fixtury.yml")
+
+        ref = ::Fixtury::Reference.new("/dependency", "some-locator-key")
+        File.binwrite(
+          File.join(dir, "fixtury.my_cache.yml"),
+          { references: { "/dependency" => ref } }.to_yaml
+        )
+
+        store = ::Fixtury::Store.new(name: :my_cache)
+        assert_equal %w[/dependency], store.references.keys
+        assert_equal "some-locator-key", store.references["/dependency"].locator_key
+
+        # The default store should not pick up the named store's references.
+        assert_equal true, ::Fixtury::Store.new.references.empty?
+      end
+    end
+
+    def test_dump_file_writes_each_named_store_to_its_own_file
+      Dir.mktmpdir do |dir|
+        ::Fixtury.configuration.filepath = File.join(dir, "fixtury.yml")
+
+        ::Fixtury.define do
+          fixture("dependency") { "dep" }
+          fixture("record", deps: "dependency") { |deps| deps.dependency }
+        end
+
+        ::Fixtury.factory("record", store: :my_cache)
+        ::Fixtury.configuration.dump_file
+
+        assert_equal true, File.file?(File.join(dir, "fixtury.yml"))
+        assert_equal true, File.file?(File.join(dir, "fixtury.my_cache.yml"))
+
+        references = ::Fixtury.configuration.stored_references(:my_cache)
+        assert_equal %w[/dependency], references.keys
+
+        ::Fixtury.configuration.reset
+        assert_equal false, File.file?(File.join(dir, "fixtury.yml"))
+        assert_equal false, File.file?(File.join(dir, "fixtury.my_cache.yml"))
+      end
+    end
+
+    def test_store_filepath_embeds_the_store_name
+      ::Fixtury.configuration.filepath = "tmp/fixtury.yml"
+
+      assert_equal "tmp/fixtury.yml", ::Fixtury.configuration.store_filepath
+      assert_equal "tmp/fixtury.yml", ::Fixtury.configuration.store_filepath(:default)
+      assert_equal "tmp/fixtury.my_cache.yml", ::Fixtury.configuration.store_filepath(:my_cache)
+    end
+
+  end
+end

--- a/test/fixtury/factory_test.rb
+++ b/test/fixtury/factory_test.rb
@@ -152,6 +152,20 @@ module Fixtury
       end
     end
 
+    def test_reset_deletes_named_store_files_even_when_stores_are_not_instantiated
+      Dir.mktmpdir do |dir|
+        ::Fixtury.configuration.filepath = File.join(dir, "fixtury.yml")
+        File.binwrite(File.join(dir, "fixtury.yml"), { references: {} }.to_yaml)
+        File.binwrite(File.join(dir, "fixtury.my_cache.yml"), { references: {} }.to_yaml)
+
+        assert_equal true, ::Fixtury.stores.empty?
+        ::Fixtury.configuration.reset
+
+        assert_equal false, File.file?(File.join(dir, "fixtury.yml"))
+        assert_equal false, File.file?(File.join(dir, "fixtury.my_cache.yml"))
+      end
+    end
+
     def test_store_filepath_embeds_the_store_name
       ::Fixtury.configuration.filepath = "tmp/fixtury.yml"
 


### PR DESCRIPTION
## Summary

Adds a factory mode to fixtury: `Fixtury.factory("some/fixture/definition")` invokes the definition every time it's called and never stores the result, so definitions can be used to generate new records on demand without mutating the global cache.

```ruby
user_a = Fixtury.factory("users/fresh")
user_b = Fixtury.factory("users/fresh")
user_a == user_b # => false, each call builds a new record
```

By default, dependencies are resolved through an ephemeral store — built fresh for the invocation (shared deps build once within a call) and discarded afterwards.

When the dependency tree is expensive, a dedicated store can be used instead:

```ruby
Fixtury.factory("users/fresh", store: :my_cache)
```

Dependencies are then resolved through (and cached in) a named store that is bootstrapped from its own file, derived from the configured filepath (`tmp/fixtury.yml` → `tmp/fixtury.my_cache.yml`), and persisted alongside the default store by `Configuration#dump_file`. The target definition itself is always invoked and never stored.

## Implementation

- `Fixtury.factory(search, store: nil)` executes the definition via `DefinitionExecutor` directly (never `Store#get`), so the result is never cached.
- `Fixtury.store` now accepts an optional name (`Fixtury.store(:my_cache)`); instantiated stores are memoized in a `Fixtury.stores` registry.
- `Store.new` takes a `name:` (default `:default`, preserving existing bootstrap behavior). Named stores bootstrap from their own file; `name: nil` creates the ephemeral store used by default factory calls.
- `Configuration#store_filepath(name)` derives the per-store filepath; `stored_references(name)` reads from it. `dump_file` writes every registered store to its own file, and `reset` deletes named store files alongside the default one.
- `Fixtury.reset` resets all registered stores.

## Testing

- New `test/fixtury/factory_test.rb` covering re-invocation, global-store isolation, fresh vs. cached dependency resolution, named store file bootstrap/dump/reset, and filepath naming.
- Full suite: 83 runs, 192 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core store lifecycle, persistence, and reset behavior across multiple YAML files; existing `Fixtury.store` callers remain compatible via the default name but dump/reset semantics are broader.
> 
> **Overview**
> Adds **factory mode** so fixture definitions can build new records on every call without touching the global fixture cache.
> 
> **`Fixtury.factory(search, store: nil)`** runs the definition through `DefinitionExecutor` each time and never persists the result. Dependencies default to an **ephemeral store** (fresh per call, shared deps once per invocation). Optional **`store: :my_cache`** resolves and caches dependencies in a **named store** while still rebuilding the target definition every time.
> 
> **Multi-store support:** `Fixtury.store` accepts an optional name and memoizes stores in `Fixtury.stores`. `Store` gains a `name` (`:default`, a symbol for named stores, or `nil` for ephemeral). **`Configuration`** maps each store to its own YAML (`fixtury.yml` vs `fixtury.my_cache.yml`), loads **`stored_references(name)`** per file, **`dump_file`** writes all instantiated stores, and **`reset`** deletes default and named store files. **`Fixtury.reset`** clears every registered store.
> 
> README documents factory mode; **`test/fixtury/factory_test.rb`** covers re-invocation, global-store isolation, dependency caching behavior, named-store bootstrap/dump/reset, and filepath naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47de792cdbe88ed0c33844dd025c8d297fcde6b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->