### PR TITLE
chore: gemspec cleanup — metadata, v2.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fixtury (2.4.0)
+    fixtury (2.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -109,7 +109,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  fixtury (2.4.0)
+  fixtury (2.4.1)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/fixtury.gemspec
+++ b/fixtury.gemspec
@@ -11,13 +11,20 @@ Gem::Specification.new do |spec|
   spec.email         = ["mike@guideline.com"]
 
   spec.summary       = "Treat fixtures like factories and factories like fixtures"
-  spec.homepage      = "https://github.com/guideline-tech/fixtury"
   spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
+
+  github_uri = "https://github.com/guideline-tech/fixtury"
+
+  spec.homepage = github_uri
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = github_uri
+  spec.metadata["changelog_uri"] = "#{github_uri}/releases"
+  spec.metadata["github_repo"] = github_uri
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  # Specify which files should be added to the gem when it is released.
   spec.files = Dir["lib/**/*"] + Dir["*.gemspec"] + Dir["bin/**/*"]
 
   spec.bindir        = "bin"
@@ -33,6 +40,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "sqlite3"
-
-  spec.required_ruby_version = ">= 3.3.0"
 end

--- a/gemfiles/rails_7.2.gemfile.lock
+++ b/gemfiles/rails_7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fixtury (2.4.0)
+    fixtury (2.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -108,7 +108,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  fixtury (2.4.0)
+  fixtury (2.4.1)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/gemfiles/rails_8.0.gemfile.lock
+++ b/gemfiles/rails_8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fixtury (2.4.0)
+    fixtury (2.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -110,7 +110,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  fixtury (2.4.0)
+  fixtury (2.4.1)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/gemfiles/rails_8.1.gemfile.lock
+++ b/gemfiles/rails_8.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fixtury (2.4.0)
+    fixtury (2.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -109,7 +109,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  fixtury (2.4.0)
+  fixtury (2.4.1)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/gemfiles/rails_8.1_minitest_5.gemfile.lock
+++ b/gemfiles/rails_8.1_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fixtury (2.4.0)
+    fixtury (2.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -106,7 +106,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  fixtury (2.4.0)
+  fixtury (2.4.1)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/lib/fixtury/version.rb
+++ b/lib/fixtury/version.rb
@@ -4,7 +4,7 @@ module Fixtury
 
   MAJOR       = 2
   MINOR       = 4
-  PATCH       = 0
+  PATCH       = 1
   PRERELEASE  = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRERELEASE].compact.join(".")


### PR DESCRIPTION
## Summary

- **`github_uri` constant**: adds `homepage_uri`, `source_code_uri`, `changelog_uri` (releases page), `github_repo`
- No dependency changes
- **Version**: 2.4.0 → 2.4.1 (patch bump)
- **`bundle update`**: Gemfile.lock + all 4 appraisal lockfiles refreshed

A new release will be kicked once merged.