### PR TITLE
Fix flaky store test racing the system clock

### DIFF
--- a/test/fixtury/store_test.rb
+++ b/test/fixtury/store_test.rb
@@ -26,13 +26,14 @@ module Fixtury
       store = ::Fixtury::Store.new(schema: schema)
       assert_equal true, store.references.empty?
 
-      t = Time.now.to_i
+      t = Time.now
+      Fixtury.stubs(:now).returns(t)
       assert_equal "foo", store["foo"]
       ref = store.references["/test/foo"]
 
       assert_equal "/test/foo", ref.name
       assert_equal "fixtury-oid-#{Process.pid}-#{"foo".object_id}", ref.locator_key
-      assert_equal t, ref.created_at
+      assert_equal t.to_i, ref.created_at
     end
 
     def test_a_store_returns_an_existing_reference_rather_than_reinvoking_the_definition


### PR DESCRIPTION
## What

`test_a_store_holds_references_to_fixtures` captured `Time.now.to_i` before creating the reference, then asserted it matched `ref.created_at` (set internally via `Fixtury.now.to_i`). If the wall-clock second ticked over between those two calls, the assertion failed by 1.

Stub `Fixtury.now` up front instead, the same pattern already used by the TTL test directly below it, so the timestamp is fixed for the whole test.

## Testing

- `bundle exec appraisal rake` across both appraisals, 5x in a row: 74 runs, 171 assertions, 0 failures each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)